### PR TITLE
Activity Indicator orientation incorrect

### DIFF
--- a/Classes/ShareKit/UI/SHKActivityIndicator.m
+++ b/Classes/ShareKit/UI/SHKActivityIndicator.m
@@ -252,7 +252,7 @@ static SHKActivityIndicator *currentIndicator = nil;
 
 - (void)setProperRotation:(BOOL)animated
 {
-	UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+	UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
 	
 	if (animated)
 	{
@@ -260,21 +260,22 @@ static SHKActivityIndicator *currentIndicator = nil;
 		[UIView setAnimationDuration:0.3];
 	}
 	
-	if (orientation == UIDeviceOrientationPortraitUpsideDown)
+	if (orientation == UIInterfaceOrientationPortraitUpsideDown)
 		self.transform = CGAffineTransformRotate(CGAffineTransformIdentity, SHKdegreesToRadians(180));	
-		
-	else if (orientation == UIDeviceOrientationPortrait)
+	
+	else if (orientation == UIInterfaceOrientationPortrait)
 		self.transform = CGAffineTransformRotate(CGAffineTransformIdentity, SHKdegreesToRadians(0)); 
 	
-	else if (orientation == UIDeviceOrientationLandscapeLeft)
+	else if (orientation == UIInterfaceOrientationLandscapeRight)
 		self.transform = CGAffineTransformRotate(CGAffineTransformIdentity, SHKdegreesToRadians(90));	
 	
-	else if (orientation == UIDeviceOrientationLandscapeRight)
+	else if (orientation == UIInterfaceOrientationLandscapeLeft)
 		self.transform = CGAffineTransformRotate(CGAffineTransformIdentity, SHKdegreesToRadians(-90));
 	
 	if (animated)
 		[UIView commitAnimations];
 }
+
 
 
 @end


### PR DESCRIPTION
Fixed issue where Activity Indicator wouldn't have the correct orientation if the app was launched in Landscape, and orientation wasn't changed until showing the indicator.
