### PR TITLE
SHKTwitter -validate method

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -286,7 +286,7 @@
 #pragma mark -
 #pragma mark Share API Methods
 
-- (BOOL)validate
+- (BOOL)validateItem
 {
 	NSString *status = [item customValueForKey:@"status"];
 	return status != nil && status.length >= 0 && status.length <= 140;
@@ -298,7 +298,7 @@
 	if (xAuth && [item customBoolForSwitchKey:@"followMe"])
 		[self followMe];	
 	
-	if (![self validate])
+	if (![self validateItem])
 		[self show];
 	
 	else


### PR DESCRIPTION
Not sure if this is intentional or not, but the SHKTwitter class defines `-validate` where all other sharers define `-validateItem`. This bit me while I was working with a collection of SHKSharer subclasses.

If there's no specific reason for the difference, this pull request renames the SHKTwitter method to match the rest.
