### PR TITLE
Minor fixes for ShareKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.perspective
 *.perspectivev3
 *.mode1v3
+*.mode2v3
 build
 .DS_Store
 Classes/ShareKit/SHKConfig.h

--- a/Classes/ShareKit/Sharers/Services/Evernote/SHKEvernote.m
+++ b/Classes/ShareKit/Sharers/Services/Evernote/SHKEvernote.m
@@ -11,6 +11,12 @@
 #import "TBinaryProtocol.h"
 #import "NSData+md5.h"
 
+// These defines should be filled in
+#define SHKEvernoteUserStoreURL    @""
+#define SHKEvernoteConsumerKey     @""
+#define SHKEvernoteSecretKey       @""
+#define SHKEvernoteNetStoreURLBase @""
+
 @implementation SHKEvernoteItem
 @synthesize note;
 


### PR DESCRIPTION
These two commits clean up a couple things:
1. Ignore `.mode2v3` files in Xcode projects
2. Add `#define`s for Evernote, which allows the project to be compiled.
