### PR TITLE
New feature - alternate text for sharers

### DIFF
--- a/Classes/Example/ExampleShareImage.m
+++ b/Classes/Example/ExampleShareImage.m
@@ -70,6 +70,7 @@
 - (void)share
 {
 	SHKItem *item = [SHKItem image:imageView.image title:@"San Francisco"];
+	[item setAlternateText:@"Golden Gate Bridge #SanFrancisco" toShareOn:@"Twitter"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	
 	[actionSheet showFromToolbar:self.navigationController.toolbar];

--- a/Classes/Example/ExampleShareLink.m
+++ b/Classes/Example/ExampleShareLink.m
@@ -56,6 +56,7 @@
 - (void)share
 {
 	SHKItem *item = [SHKItem URL:webView.request.URL title:[webView pageTitle]];
+	[item setAlternateText:[NSString stringWithFormat:@"%@ #channel",[webView pageTitle]] toShareOn:@"Twitter"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	[actionSheet showFromToolbar:self.navigationController.toolbar]; 
 }

--- a/Classes/Example/ExampleShareText.m
+++ b/Classes/Example/ExampleShareText.m
@@ -77,6 +77,8 @@
 
 	
 	SHKItem *item = [SHKItem text:text];
+	[item setAlternateText:[item.text stringByAppendingString:@" #ShareKit"] toShareOn:@"Twitter"];
+	[item setAlternateText:[item.text stringByAppendingString:@" <br/><br/>Alternate text for Email Action"] toShareOn:@"Email"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	
 	[actionSheet showFromToolbar:self.navigationController.toolbar];

--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
@@ -166,6 +166,7 @@
 	{
 		self.shareDelegate = self;
 		self.item = [[[SHKItem alloc] init] autorelease];
+		self.item.currentOwner = self;
 				
 		if ([self respondsToSelector:@selector(modalPresentationStyle)])
 			self.modalPresentationStyle = [SHK modalPresentationStyle];
@@ -187,6 +188,8 @@
 	// Create controller and set share options
 	SHKSharer *controller = [[self alloc] init];
 	controller.item = i;
+	controller.item.currentOwner = controller;
+
 	
 	// share and/or show UI
 	[controller share];

--- a/Classes/ShareKit/Core/SHKItem.h
+++ b/Classes/ShareKit/Core/SHKItem.h
@@ -55,6 +55,7 @@ typedef enum
 	
 	@private
 		NSMutableDictionary *custom;
+		NSObject *currentOwner;
 }
 
 @property (nonatomic)			SHKShareType shareType;
@@ -71,10 +72,14 @@ typedef enum
 @property (nonatomic, retain)	NSString *mimeType;
 @property (nonatomic, retain)	NSString *filename;
 
+@property (assign)	NSObject *currentOwner;
+
 + (SHKItem *)URL:(NSURL *)url title:(NSString *)title;
 + (SHKItem *)image:(UIImage *)image title:(NSString *)title;
 + (SHKItem *)text:(NSString *)text;
 + (SHKItem *)file:(NSData *)data filename:(NSString *)filename mimeType:(NSString *)mimeType title:(NSString *)title;
+
+- (void)setAlternateText:(NSString *)alternateText toShareOn:(NSString *)sharer;
 
 - (void)setCustomValue:(NSString *)value forKey:(NSString *)key;
 - (NSString *)customValueForKey:(NSString *)key;

--- a/Classes/ShareKit/Core/SHKItem.m
+++ b/Classes/ShareKit/Core/SHKItem.m
@@ -26,6 +26,7 @@
 //
 
 #import "SHKItem.h"
+#import "SHKSharer.h"
 #import "SHK.h"
 
 
@@ -37,7 +38,7 @@
 @implementation SHKItem
 
 @synthesize shareType;
-@synthesize URL, image, title, text, tags, data, mimeType, filename;
+@synthesize URL, image, title, text, tags, data, mimeType, filename, currentOwner;
 @synthesize custom;
 
 - (void)dealloc
@@ -133,6 +134,21 @@
 - (BOOL)customBoolForSwitchKey:(NSString *)key
 {
 	return [[custom objectForKey:key] isEqualToString:SHKFormFieldSwitchOn];
+}
+
+#pragma mark -
+
+//Special getter for convenience in sharers
+//It "magically" gets alternate text set for particular sharer
+- (NSString *)text {
+	NSString *sharerTitle = [(SHKSharer *)currentOwner sharerTitle];
+	NSString *alternateText = [self customValueForKey:[NSString stringWithFormat:@"alternateTextFor%@",sharerTitle]];
+	return (alternateText == nil) ? text : alternateText;
+}
+
+//Adds ability to add custom text for each sharer by name
+- (void)setAlternateText:(NSString *)alternateText toShareOn:(NSString *)sharer {
+	[self setCustomValue:alternateText forKey:[NSString stringWithFormat:@"alternateTextFor%@",sharer]];
 }
 
 

--- a/Classes/ShareKit/Core/SHKOfflineSharer.m
+++ b/Classes/ShareKit/Core/SHKOfflineSharer.m
@@ -79,6 +79,7 @@
 	// create sharer
 	self.sharer = [[NSClassFromString(sharerId) alloc] init];
 	sharer.item = item;
+	sharer.item.currentOwner = sharer;
 	sharer.quiet = YES;
 	sharer.shareDelegate = self;
 	

--- a/Classes/ShareKit/Localization/ru.lproj/Localizable.strings
+++ b/Classes/ShareKit/Localization/ru.lproj/Localizable.strings
@@ -1,0 +1,91 @@
+"Email" = "Email";
+"Username" = "Имя";
+"Password" = "Пароль";
+"Follow %@" = "Follow %@";
+"Continue" = "Продолжить";
+"Share" = "Отправить";
+"More..." = "Другие...";
+"Cancel" = "Отмена";
+"Slug" = "Slug";
+"Private" = "Личное";
+"Public" = "Открытое";
+"Caption" = "Заголовок";
+"Title" = "Название";
+"Tags" = "Теги";
+"Close" = "Закрыть";
+"Notes" = "Заметки";
+"Note" = "Заметка";
+"Share" = "Отправить";
+"Shared" = "Отправлено";
+"Edit" = "Редактировать";
+"Actions" = "Действия";
+"Services" = "Сервисы";
+"Send to %@" = "Отправить %@";
+"Copy" = "Копировать";
+"Copied!" = "Скопировано!";
+"Saving to %@" = "Отправить на %@";
+"Saved!" = "Отправлено!";
+"Offline" = "Нет сети";
+"Error" = "Ошибка";
+"Login" = "Вход";
+"Logging In..." = "Подключение...";
+"Login Error" = "Ошибка входа";
+"Connecting..." = "Подключение...";
+
+"Shortening URL..." = "Сокращаю ссылку...";
+"Shorten URL Error" = "Ошибка сокращения ссылки";
+"We could not shorten the URL." = "Невозможно сократить ссылку.";
+
+"Create a free account at %@" = "Создать бесплатный аккаунт на %@";
+"Create an account at %@" = "Создать аккаунт на %@";
+
+"Send to Twitter" = "Отправить в Twitter";
+
+"Message is too long" = "Слишком длинное сообщение";
+"Twitter posts can only be 140 characters in length." = "Twitter посты могут быть не длиннее 140 символов.";
+"Message is empty" = "Пустое сообщение";
+"You must enter a message in order to post." = "Вы должны ввести сообщение.";
+
+"Enter your message:" = "Ваше сообщение:";
+
+"Invalid email or password." = "Неверный email или пароль.";
+"The service encountered an error. Please try again later." = "У сервиса произошла ошибка. Попробуйте, пожалуйста, позже.";
+"There was a sending your post to Tumblr." = "Произошла ошибка при oтправке на Tumblr.";
+
+"There was an error saving to Pinboard" = "Произошла ошибка при oтправке на Pinboard";
+
+"Sorry, Instapaper did not accept your credentials. Please try again." = "Извините, но Instapaper не принял ваши данные. Попробуйте, пожалуйста, еще раз.";
+"Sorry, Instapaper encountered an error. Please try again." = "Извините, у Instapaper возникла ошибка. Попробуйте, пожалуйста, еще раз.";
+"There was a problem saving to Instapaper." = "Произошла ошибка при oтправке на Instapaper.";
+
+"Incorrect username and password" = "Неверные имя и пароль";
+"There was an error logging into Google Reader" = "Ошибка входа в Google Reader";
+"There was a problem authenticating your account." = "Произошла ошибка авторизации Вашего аккаунта.";
+"There was a problem saving your note." = "Произошла ошибка при oтправке Вашей заметки.";
+
+"There was a problem saving to Delicious." = "Произошла ошибка при oтправке на Delicious.";
+
+"Open in Safari" = "Открыть в Safari";
+"Attached: %@" = "Прикреплено: %@";
+
+"You must be online to login to %@" = "Вы должны быть подключены к Интернет чтобы войти на %@";
+
+"Auto Share" = "Авто-отправка";
+"Enable auto share to skip this step in the future." = "Включите авто-отправку, чтобы пропустить это шаг в дальнейшем.";
+
+"You must be online in order to share with %@" = "Вы должны быть подключены к Интернет чтобы слать на %@";
+"There was an error while sharing" = "Произошла ошибка при oтправке";
+
+"Could not authenticate you. Please relogin." = "Невозможно Вас аутентифицировать. Пожалуйста, войдите еще раз.";
+"There was a problem requesting authorization from %@" = "Ошибка при получении запроса аутентификации от %@";
+"Request Error" = "Ошибка запроса";
+"There was an error while sharing" = "Произошла ошибка при oтправке";
+
+"Authorize Error" = "Ошибка авторизации";
+"There was an error while authorizing" = "Произошла ошибка при авторизации";
+
+"Authenticating..." = "Авторизация...";
+"There was a problem requesting access from %@" = "Произошла ошибка получения доступа к %@";
+
+"Access Error" = "Ошибка доступа";
+"There was an error while sharing" = "Произошла ошибка при oтправке";

--- a/Classes/ShareKit/SHKConfig.h
+++ b/Classes/ShareKit/SHKConfig.h
@@ -86,6 +86,13 @@
 #define SHKSharedWithSignature		0
 
 
+//Evernote settings
+#define SHKEvernoteUserStoreURL		@""
+#define SHKEvernoteConsumerKey		@""
+#define SHKEvernoteSecretKey		@""
+#define SHKEvernoteNetStoreURLBase	@""
+
+
 
 /*
  UI Configuration : Basic
@@ -117,6 +124,8 @@
 
 // Append 'Shared With 'Signature to Email (and related forms)
 #define SHKSharedWithSignature		0
+
+
 
 /*
  UI Configuration : Advanced


### PR DESCRIPTION
I've added new feature - alternate text for sharers. It works globally and doesn't require sharers code change, so it's transparent. It allows you setting custom text which will be shared if the give sharer is selected. Sharers are identified by their title (exactly as people see them in UIActionSheet which should be clear for users).
Examples updated.

Example right here:

``` objective-c
    SHKItem *item = [SHKItem text:@"This is a text to share via ShareKit"];
    [item setAlternateText:@"This is a text to share via #ShareKit" toShareOn:@"Twitter"];
    [item setAlternateText:@"This is a text to share via Email" toShareOn:@"Email"];
    SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
    [actionSheet showFromToolbar:self.navigationController.toolbar];
```

Each sharer will get alternate text if it was set when getting "text" property of SHKItem. If no alternate text given, the property value is returned.

When it is needed. First of all - Twitter. Twitter uses markup which is useless for other places like Facebook and could look strange there. But allowing user create custom message for Twitter we simply solve the problem and bring more flexibility to awesome ShareKit.
