### PR TITLE
New feature - Alternate Text for sharers

### DIFF
--- a/Classes/Example/ExampleShareImage.m
+++ b/Classes/Example/ExampleShareImage.m
@@ -70,6 +70,7 @@
 - (void)share
 {
 	SHKItem *item = [SHKItem image:imageView.image title:@"San Francisco"];
+	[item setAlternateText:@"Golden Gate Bridge #SanFrancisco" toShareOn:@"Twitter"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	
 	[actionSheet showFromToolbar:self.navigationController.toolbar];

--- a/Classes/Example/ExampleShareLink.m
+++ b/Classes/Example/ExampleShareLink.m
@@ -56,6 +56,7 @@
 - (void)share
 {
 	SHKItem *item = [SHKItem URL:webView.request.URL title:[webView pageTitle]];
+	[item setAlternateText:[NSString stringWithFormat:@"%@ #channel",[webView pageTitle]] toShareOn:@"Twitter"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	[actionSheet showFromToolbar:self.navigationController.toolbar]; 
 }

--- a/Classes/Example/ExampleShareText.m
+++ b/Classes/Example/ExampleShareText.m
@@ -77,6 +77,8 @@
 
 	
 	SHKItem *item = [SHKItem text:text];
+	[item setAlternateText:[item.text stringByAppendingString:@" #ShareKit"] toShareOn:@"Twitter"];
+	[item setAlternateText:[item.text stringByAppendingString:@" <br/><br/>Alternate text for Email Action"] toShareOn:@"Email"];
 	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
 	
 	[actionSheet showFromToolbar:self.navigationController.toolbar];

--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
@@ -166,6 +166,7 @@
 	{
 		self.shareDelegate = self;
 		self.item = [[[SHKItem alloc] init] autorelease];
+		self.item.currentOwner = self;
 				
 		if ([self respondsToSelector:@selector(modalPresentationStyle)])
 			self.modalPresentationStyle = [SHK modalPresentationStyle];
@@ -187,6 +188,8 @@
 	// Create controller and set share options
 	SHKSharer *controller = [[self alloc] init];
 	controller.item = i;
+	controller.item.currentOwner = controller;
+
 	
 	// share and/or show UI
 	[controller share];

--- a/Classes/ShareKit/Core/SHKItem.h
+++ b/Classes/ShareKit/Core/SHKItem.h
@@ -55,6 +55,7 @@ typedef enum
 	
 	@private
 		NSMutableDictionary *custom;
+		NSObject *currentOwner;
 }
 
 @property (nonatomic)			SHKShareType shareType;
@@ -71,10 +72,14 @@ typedef enum
 @property (nonatomic, retain)	NSString *mimeType;
 @property (nonatomic, retain)	NSString *filename;
 
+@property (assign)	NSObject *currentOwner;
+
 + (SHKItem *)URL:(NSURL *)url title:(NSString *)title;
 + (SHKItem *)image:(UIImage *)image title:(NSString *)title;
 + (SHKItem *)text:(NSString *)text;
 + (SHKItem *)file:(NSData *)data filename:(NSString *)filename mimeType:(NSString *)mimeType title:(NSString *)title;
+
+- (void)setAlternateText:(NSString *)alternateText toShareOn:(NSString *)sharer;
 
 - (void)setCustomValue:(NSString *)value forKey:(NSString *)key;
 - (NSString *)customValueForKey:(NSString *)key;

--- a/Classes/ShareKit/Core/SHKItem.m
+++ b/Classes/ShareKit/Core/SHKItem.m
@@ -26,6 +26,7 @@
 //
 
 #import "SHKItem.h"
+#import "SHKSharer.h"
 #import "SHK.h"
 
 
@@ -37,7 +38,7 @@
 @implementation SHKItem
 
 @synthesize shareType;
-@synthesize URL, image, title, text, tags, data, mimeType, filename;
+@synthesize URL, image, title, text, tags, data, mimeType, filename, currentOwner;
 @synthesize custom;
 
 - (void)dealloc
@@ -133,6 +134,21 @@
 - (BOOL)customBoolForSwitchKey:(NSString *)key
 {
 	return [[custom objectForKey:key] isEqualToString:SHKFormFieldSwitchOn];
+}
+
+#pragma mark -
+
+//Special getter for convenience in sharers
+//It "magically" gets alternate text set for particular sharer
+- (NSString *)text {
+	NSString *sharerTitle = [(SHKSharer *)currentOwner sharerTitle];
+	NSString *alternateText = [self customValueForKey:[NSString stringWithFormat:@"alternateTextFor%@",sharerTitle]];
+	return (alternateText == nil) ? text : alternateText;
+}
+
+//Adds ability to add custom text for each sharer by name
+- (void)setAlternateText:(NSString *)alternateText toShareOn:(NSString *)sharer {
+	[self setCustomValue:alternateText forKey:[NSString stringWithFormat:@"alternateTextFor%@",sharer]];
 }
 
 

--- a/Classes/ShareKit/Core/SHKOfflineSharer.m
+++ b/Classes/ShareKit/Core/SHKOfflineSharer.m
@@ -79,6 +79,7 @@
 	// create sharer
 	self.sharer = [[NSClassFromString(sharerId) alloc] init];
 	sharer.item = item;
+	sharer.item.currentOwner = sharer;
 	sharer.quiet = YES;
 	sharer.shareDelegate = self;
 	

--- a/Classes/ShareKit/SHKConfig.h
+++ b/Classes/ShareKit/SHKConfig.h
@@ -86,6 +86,13 @@
 #define SHKSharedWithSignature		0
 
 
+//Evernote settings
+#define SHKEvernoteUserStoreURL		@""
+#define SHKEvernoteConsumerKey		@""
+#define SHKEvernoteSecretKey		@""
+#define SHKEvernoteNetStoreURLBase	@""
+
+
 
 /*
  UI Configuration : Basic
@@ -117,6 +124,8 @@
 
 // Append 'Shared With 'Signature to Email (and related forms)
 #define SHKSharedWithSignature		0
+
+
 
 /*
  UI Configuration : Advanced


### PR DESCRIPTION
I've added new feature - alternate text for sharers. It works globally and doesn't require sharers code change, so it's transparent. It allows you setting custom text which will be shared if the give sharer is selected. Sharers are identified by their title (exactly as people see them in UIActionSheet which should be clear for users).
Examples updated.

Example right here:

``` objective-c
    SHKItem *item = [SHKItem text:@"This is a text to share via ShareKit"];
    [item setAlternateText:@"This is a text to share via #ShareKit" toShareOn:@"Twitter"];
    [item setAlternateText:@"This is a text to share via Email" toShareOn:@"Email"];
    SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
    [actionSheet showFromToolbar:self.navigationController.toolbar];
```

Each sharer will get alternate text if it was set when getting "text" property of SHKItem. If no alternate text given, the property value is returned.

When it is needed. First of all - Twitter. Twitter uses markup which is useless for other places like Facebook and could look strange there. But allowing user create custom message for Twitter we simply solve the problem and bring more flexibility to awesome ShareKit.
