### PR TITLE
Fix Issue #220 - Quotes in url title

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -570,6 +570,7 @@ NSString * SHKEncode(NSString * value)
 	string = [string stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
 	string = [string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	string = [string stringByReplacingOccurrencesOfString:@"&" withString:@"%26"];
+	string = [string stringByReplacingOccurrencesOfString:@"\"" withString:@"'"];
 	
 	return string;	
 }


### PR DESCRIPTION
If you have quotes in url title it doesn't work with Facebook. You must convert the " char to ' char to post the link to Facebook.
