### PR TITLE
Fix Issue #254 - IOS 5 Cancel Button

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -127,7 +127,13 @@ BOOL SHKinit;
 	if (currentView != nil)
 	{
 		self.pendingView = vc;
-		[[currentView parentViewController] dismissModalViewControllerAnimated:YES];
+		if ([currentView respondsToSelector:@selector(presentingViewController)]) {
+			[[currentView presentingViewController] dismissModalViewControllerAnimated:YES];
+		}
+		else
+		{
+			[[currentView parentViewController] dismissModalViewControllerAnimated:YES];
+		}
 		return;
 	}
 		
@@ -179,7 +185,11 @@ BOOL SHKinit;
 	if (currentView != nil)
 	{
 		// Dismiss the modal view
-		if ([currentView parentViewController] != nil)
+		if ([currentView respondsToSelector:@selector(presentingViewController)] && [currentView presentingViewController] != nil) {
+			self.isDismissingView = YES;
+			[[currentView presentingViewController] dismissModalViewControllerAnimated:animated];
+		}
+		else if ([currentView parentViewController] != nil)
 		{
 			self.isDismissingView = YES;
 			[[currentView parentViewController] dismissModalViewControllerAnimated:animated];


### PR DESCRIPTION
Fix for issue https://github.com/ideashower/ShareKit/issues/254.

In iOS 5, a modally presented view controller has a nil parentViewController, and instead the presenter is presentingViewController. Changed the attempts to dismiss the view using the parentViewController to check for the iOS 5 selector, and used it if available.
