### PR TITLE
minor fixes for sharekit

### DIFF
--- a/Classes/ShareKit/SHKConfig.h
+++ b/Classes/ShareKit/SHKConfig.h
@@ -115,9 +115,6 @@
 // ShareMenu Ordering
 #define SHKShareMenuAlphabeticalOrder 1 // Setting this to 1 will show list in Alphabetical Order, setting to 0 will follow the order in SHKShares.plist
 
-// Append 'Shared With 'Signature to Email (and related forms)
-#define SHKSharedWithSignature		0
-
 /*
  UI Configuration : Advanced
  ------

--- a/Classes/ShareKit/SHKConfig.h
+++ b/Classes/ShareKit/SHKConfig.h
@@ -85,7 +85,16 @@
 // Append 'Shared With 'Signature to Email (and related forms)
 #define SHKSharedWithSignature		0
 
+//#define SHKEvernoteUserStoreURL @"https://sandbox.evernote.com/edam/user"
+//#define SHKEvernoteNetStoreURLBase @"http://sandbox.evernote.com/edam/note/"
+//#define SHKEvernoteUserStoreURL @"https://www.evernote.com/edam/user"
+//#define SHKEvernoteNetStoreURLBase @"http://www.evernote.com/edam/note/"
 
+#define SHKEvernoteUserStoreURL @""
+#define SHKEvernoteNetStoreURLBase @""
+
+#define SHKEvernoteConsumerKey @""
+#define SHKEvernoteSecretKey @""
 
 /*
  UI Configuration : Basic

--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -289,7 +289,7 @@
 - (BOOL)validate
 {
 	NSString *status = [item customValueForKey:@"status"];
-	return status != nil && status.length >= 0 && status.length <= 140;
+	return status != nil && status.length > 0 && status.length <= 140;
 }
 
 - (BOOL)send


### PR DESCRIPTION
There are three small changes:
- The current master head doesn't compile due to missing evernote #defines in the config file. I added empty ones.
- #define SHKSharedWithSignature appears twice in the config file
- SHKTwitter.m validate checks for status.length >= 0, but should check for status.length > 0.

Thanks! 
